### PR TITLE
Rebase unity bro exe onto master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,10 @@ __pycache__/
 *.txt.uncompressed
 *.br
 *.unbr
+*.bro
+*.unbro
+tools/bro
+build/
+dist/
+cmake/
+commits.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ else()
   message(STATUS "Build type is '${CMAKE_BUILD_TYPE}'")
 endif()
 
+set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "OSX Architectures" FORCE)
+
 include(CheckCSourceCompiles)
 check_c_source_compiles(
   "#if defined(__EMSCRIPTEN__)

--- a/build.pl
+++ b/build.pl
@@ -1,0 +1,27 @@
+package Main;
+
+use Getopt::Long;
+
+my $package = 0;
+
+GetOptions(
+"package" => \$package
+) or croak ("illegal cmdline options");
+
+if ($package)
+{
+	my $stamp = "commits.txt";
+
+	print "writing revision hash stamp \n";
+	open(FILE, ">$stamp") or die "Could not open file: $!";
+	print FILE `git config --get remote.origin.url`;
+	print FILE `git rev-parse HEAD`;
+	close(FILE);
+
+	system("zip", "-r", "builds.zip", "python/bro.py", $stamp, "dist");
+}
+else
+{
+	system("python", "setup.py", "bdist_egg");
+}
+exit();

--- a/build.py
+++ b/build.py
@@ -48,7 +48,7 @@ os.chdir('..')
 if not os.path.exists('dist'):
     os.mkdir('dist')
 
-if sys.platform == 'win32':
+if WINDOWS:
     if not os.path.exists('dist/win_x86_64'):
         os.mkdir('dist/win_x86_64')
     shutil.copy2('cmake/brotli.exe', 'dist/win_x86_64/brotli.exe')

--- a/build.py
+++ b/build.py
@@ -43,3 +43,6 @@ commits = open('dist/commits.txt', 'w')
 subprocess.run('git config --get remote.origin.url', shell=True, stdout=commits)
 subprocess.run('git rev-parse HEAD', shell=True, stdout=commits)
 commits.close()
+
+# Copy license file
+shutil.copy2('LICENSE', 'dist/LICENSE.txt')

--- a/build.py
+++ b/build.py
@@ -53,9 +53,9 @@ if WINDOWS:
         os.mkdir('dist/win_x86_64')
     shutil.copy2('cmake/brotli.exe', 'dist/win_x86_64/brotli.exe')
 elif sys.platform == 'darwin':
-    if not os.path.exists('dist/macos_x86_64'):
-        os.mkdir('dist/macos_x86_64')
-    shutil.copy2('cmake/brotli', 'dist/macos_x86_64/brotli')
+    if not os.path.exists('dist/macos'):
+        os.mkdir('dist/macos')
+    shutil.copy2('cmake/brotli', 'dist/macos/brotli')
 else:
     if not os.path.exists('dist/linux_x86_64'):
         os.mkdir('dist/linux_x86_64')

--- a/build.py
+++ b/build.py
@@ -1,0 +1,45 @@
+# Controls running cmake, building, and copying files to the dist folder for the various
+# platforms.
+import os
+import shutil
+import sys
+import subprocess
+
+# build the brotli exe using cmake
+if not os.path.exists('cmake'):
+    os.mkdir('cmake')
+
+os.chdir('cmake')
+
+if sys.platform == 'win32':
+    os.system('cmake -G "NMake Makefiles" ..')
+    os.system('nmake')
+else:
+    os.system('cmake -G "Unix Makefiles" ..')
+    os.system('make')
+
+os.chdir('..')
+
+# Copy the build to the dist folder
+if not os.path.exists('dist'):
+    os.mkdir('dist')
+
+if sys.platform == 'win32':
+    if not os.path.exists('dist/win_x86_64'):
+        os.mkdir('dist/win_x86_64')
+    shutil.copy2('cmake/brotli.exe', 'dist/win_x86_64/brotli.exe')
+elif sys.platform == 'darwin':
+    if not os.path.exists('dist/macos_x86_64'):
+        os.mkdir('dist/macos_x86_64')
+    shutil.copy2('cmake/brotli', 'dist/macos_x86_64/brotli')
+else:
+    if not os.path.exists('dist/linux_x86_64'):
+        os.mkdir('dist/linux_x86_64')
+    shutil.copy2('cmake/brotli', 'dist/linux_x86_64/brotli')
+
+
+# Create the commits.txt file
+commits = open('dist/commits.txt', 'w')
+subprocess.run('git config --get remote.origin.url', shell=True, stdout=commits)
+subprocess.run('git rev-parse HEAD', shell=True, stdout=commits)
+commits.close()

--- a/c/enc/encode.c
+++ b/c/enc/encode.c
@@ -1135,7 +1135,12 @@ static BROTLI_BOOL EncodeData(
   {
     const uint32_t metablock_size =
         (uint32_t)(s->input_pos_ - s->last_flush_pos_);
-    uint8_t* storage = GetBrotliStorage(s, 2 * metablock_size + 503);
+
+    // add extra storage to accommodate the comment parameter
+    size_t embedded_comment_size = s->params.comment ? srtlen(s->params.comment) : 0;
+    size_t encoded_embedded_comment_size = embedded_comment_size ? 6 + embedded_comment_size : 0;
+    const size_t max_brotli_storage_needed = encoded_embedded_comment_size + 2 * metablock_size + 503;
+    uint8_t* storage = GetBrotliStorage(s, max_brotli_storage_needed);
     size_t storage_ix = s->last_bytes_bits_;
     if (BROTLI_IS_OOM(m)) return BROTLI_FALSE;
     storage[0] = (uint8_t)s->last_bytes_;

--- a/c/enc/encode.c
+++ b/c/enc/encode.c
@@ -667,6 +667,7 @@ static void BrotliEncoderInitParams(BrotliEncoderParams* params) {
   params->quality = BROTLI_DEFAULT_QUALITY;
   params->lgwin = BROTLI_DEFAULT_WINDOW;
   params->lgblock = 0;
+  params->comment = NULL;
   params->stream_offset = 0;
   params->size_hint = 0;
   params->disable_literal_context_modeling = BROTLI_FALSE;

--- a/c/enc/encode.c
+++ b/c/enc/encode.c
@@ -1137,7 +1137,7 @@ static BROTLI_BOOL EncodeData(
         (uint32_t)(s->input_pos_ - s->last_flush_pos_);
 
     // add extra storage to accommodate the comment parameter
-    size_t embedded_comment_size = s->params.comment ? srtlen(s->params.comment) : 0;
+    size_t embedded_comment_size = s->params.comment ? strlen(s->params.comment) : 0;
     size_t encoded_embedded_comment_size = embedded_comment_size ? 6 + embedded_comment_size : 0;
     const size_t max_brotli_storage_needed = encoded_embedded_comment_size + 2 * metablock_size + 503;
     uint8_t* storage = GetBrotliStorage(s, max_brotli_storage_needed);

--- a/c/enc/params.h
+++ b/c/enc/params.h
@@ -35,6 +35,7 @@ typedef struct BrotliEncoderParams {
   int quality;
   int lgwin;
   int lgblock;
+  char *comment;
   size_t stream_offset;
   size_t size_hint;
   BROTLI_BOOL disable_literal_context_modeling;

--- a/c/include/brotli/encode.h
+++ b/c/include/brotli/encode.h
@@ -218,7 +218,11 @@ typedef enum BrotliEncoderParameter {
    * maximal window size have the same effect. Values greater than 2**30 are not
    * allowed.
    */
-  BROTLI_PARAM_STREAM_OFFSET = 9
+  BROTLI_PARAM_STREAM_OFFSET = 9,
+  /**
+   * TODO
+  */
+  BROTLI_PARAM_COMMENT = 10
 } BrotliEncoderParameter;
 
 /**

--- a/c/include/brotli/encode.h
+++ b/c/include/brotli/encode.h
@@ -220,8 +220,11 @@ typedef enum BrotliEncoderParameter {
    */
   BROTLI_PARAM_STREAM_OFFSET = 9,
   /**
-   * TODO
-  */
+   * Embedded comment stream to allow data to be identified as Brotli or
+   * uncompressed data.
+   * 
+   * Used for Unity's Decompression Fallback option.
+   */
   BROTLI_PARAM_COMMENT = 10
 } BrotliEncoderParameter;
 

--- a/c/tools/brotli.c
+++ b/c/tools/brotli.c
@@ -115,6 +115,7 @@ typedef struct {
   const char* output_path;
   const char* dictionary_path;
   const char* suffix;
+  const char* comment;
   int not_input_indices[MAX_OPTIONS];
   size_t longest_path_len;
   size_t input_count;
@@ -207,6 +208,7 @@ static Command ParseParams(Context* params) {
   BROTLI_BOOL keep_set = BROTLI_FALSE;
   BROTLI_BOOL lgwin_set = BROTLI_FALSE;
   BROTLI_BOOL suffix_set = BROTLI_FALSE;
+  BROTLI_BOOL comment_set = BROTLI_FALSE;
   BROTLI_BOOL after_dash_dash = BROTLI_FALSE;
   Command command = ParseAlias(argv[0]);
 
@@ -389,6 +391,13 @@ static Command ParseParams(Context* params) {
           }
           suffix_set = BROTLI_TRUE;
           params->suffix = argv[i];
+        } else if (c == 'C') {
+          if (comment_set) {
+            fprintf(stderr, "comment already set\n");
+            return COMMAND_INVALID;
+          }
+          comment_set = BROTLI_TRUE;
+          params->comment = argv[i];
         }
       }
     } else {  /* Double-dash. */
@@ -535,6 +544,13 @@ static Command ParseParams(Context* params) {
           }
           suffix_set = BROTLI_TRUE;
           params->suffix = value;
+        } else if (strncmp("comment", arg, key_len) == 0) {
+          if (comment_set) {
+            fprintf(stderr, "comment already set\n");
+            return COMMAND_INVALID;
+          }
+          comment_set = BROTLI_TRUE;  
+          params->comment = value;  
         } else {
           fprintf(stderr, "invalid parameter: [%s]\n", arg);
           return COMMAND_INVALID;
@@ -608,6 +624,9 @@ static void PrintHelp(const char* name, BROTLI_BOOL error) {
   fprintf(media,
 "  -S SUF, --suffix=SUF        output file suffix (default:'%s')\n",
           DEFAULT_SUFFIX);
+  fprintf(media,               // TODO example usage of comment
+"  -C COMM, --comment=COMM     comment for identifying whether data is\n"
+"                              brotli compressed or uncompressed\n");
   fprintf(media,
 "  -V, --version               display version and exit\n"
 "  -Z, --best                  use best compression level (11) (default)\n"
@@ -1167,6 +1186,8 @@ int main(int argc, char** argv) {
   context.output_path = NULL;
   context.dictionary_path = NULL;
   context.suffix = DEFAULT_SUFFIX;
+  context.comment = NULL;
+
   for (i = 0; i < MAX_OPTIONS; ++i) context.not_input_indices[i] = 0;
   context.longest_path_len = 1;
   context.input_count = 0;

--- a/python/_brotli.c
+++ b/python/_brotli.c
@@ -344,6 +344,8 @@ PyDoc_STRVAR(brotli_Compressor_doc,
 "  lgblock (int, optional): Base 2 logarithm of the maximum input block size.\n"
 "    Range is 16 to 24. If set to 0, the value will be set based on the\n"
 "    quality. Defaults to 0.\n"
+"  comment (string, optional): A comment that will be added as the leading\n"
+"     metadata metablock.\n"
 "\n"
 "Raises:\n"
 "  brotli.error: If arguments are invalid.\n");
@@ -378,16 +380,18 @@ static int brotli_Compressor_init(brotli_Compressor *self, PyObject *args, PyObj
   int quality = -1;
   int lgwin = -1;
   int lgblock = -1;
+  char *comment = "";
   int ok;
 
-  static const char *kwlist[] = {"mode", "quality", "lgwin", "lgblock", NULL};
+  static const char *kwlist[] = {"mode", "quality", "lgwin", "lgblock", "comment", NULL};
 
   ok = PyArg_ParseTupleAndKeywords(args, keywds, "|O&O&O&O&:Compressor",
                     (char **) kwlist,
                     &mode_convertor, &mode,
                     &quality_convertor, &quality,
                     &lgwin_convertor, &lgwin,
-                    &lgblock_convertor, &lgblock);
+                    &lgblock_convertor, &lgblock,
+                    &comment);
   if (!ok)
     return -1;
   if (!self->enc)
@@ -401,6 +405,7 @@ static int brotli_Compressor_init(brotli_Compressor *self, PyObject *args, PyObj
     BrotliEncoderSetParameter(self->enc, BROTLI_PARAM_LGWIN, (uint32_t)lgwin);
   if (lgblock != -1)
     BrotliEncoderSetParameter(self->enc, BROTLI_PARAM_LGBLOCK, (uint32_t)lgblock);
+  BrotliEncoderSetParameter(self->enc, BROTLI_PARAM_COMMENT, comment);
 
   return 0;
 }

--- a/python/bro.py
+++ b/python/bro.py
@@ -138,6 +138,19 @@ def main(args=None):
     else:
         outfile = get_binary_stdio('stdout')
 
+    if options.dictfile:
+        if not os.path.isfile(options.dictfile):
+            parser.error('file "%s" not found' % options.dictfile)
+        with open(options.dictfile, "rb") as dictfile:
+            custom_dictionary = dictfile.read()
+    else:
+        custom_dictionary = ''
+
+    if options.comment:
+        archive_comment = options.comment
+    else:
+        archive_comment = ''
+
     try:
         if options.decompress:
             data = brotli.decompress(data)

--- a/python/bro.py
+++ b/python/bro.py
@@ -114,6 +114,13 @@ def main(args=None):
         help='Base 2 logarithm of the maximum input block size. '
         'Range is 16 to 24. If set to 0, the value will be set based '
         'on the quality. Defaults to 0.')
+    params.add_argument(
+        '--comment',
+        type=str,
+        dest='comment',
+        help='Archive comment.',
+        default = None
+    )
     # set default values using global DEFAULT_PARAMS dictionary
     parser.set_defaults(**DEFAULT_PARAMS)
 
@@ -138,14 +145,6 @@ def main(args=None):
     else:
         outfile = get_binary_stdio('stdout')
 
-    if options.dictfile:
-        if not os.path.isfile(options.dictfile):
-            parser.error('file "%s" not found' % options.dictfile)
-        with open(options.dictfile, "rb") as dictfile:
-            custom_dictionary = dictfile.read()
-    else:
-        custom_dictionary = ''
-
     if options.comment:
         archive_comment = options.comment
     else:
@@ -160,7 +159,8 @@ def main(args=None):
                 mode=options.mode,
                 quality=options.quality,
                 lgwin=options.lgwin,
-                lgblock=options.lgblock)
+                lgblock=options.lgblock,
+                comment=options.archive_comment)
     except brotli.error as e:
         parser.exit(1,
                     'bro: error: %s: %s' % (e, options.infile or 'sys.stdin'))


### PR DESCRIPTION
*Upon approval and being merged, this branch should replace unity_bro_exe*

This PR is for taking our commits from the unity_bro_exe branch and applying them to the updated version of brotli (our master branch is already in sync with the updated version of brotli, and purposely excludes these Unity specific commits). The branch unity_bro_exe is the one that we reference in the editor as the brotli executable.

I did the following to test the changes:

1. Update unity_bro_exe to my branch name in: https://github.com/Unity-Technologies/emscripten-builder/blob/main/build_brotli.py
2. Build brotli: https://unity-ci.cds.internal.unity3d.com/project/949?nav=jobDefinitions
3. Manually copy the zip here: https://github.cds.internal.unity3d.com/unity/unity/tree/trunk/External/Compression/Brotli/Brotli 
4. Create a new trunk build with the change and test out building and playing a game with brotli compression to make sure things look as expected

I only tested this on Mac so far, I plan to test on Windows but will reach out to QA for help testing Linux. Decompression fallback should also be tested.
These are the brotli builds I generated with my changes (step 2 above):

- Windows: https://unity-ci.cds.internal.unity3d.com/job/25242712/artifacts
- Mac: https://unity-ci.cds.internal.unity3d.com/job/25242710/artifacts
- Linux: https://unity-ci.cds.internal.unity3d.com/job/25546483/artifacts